### PR TITLE
Kafka REST without jackson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build/
 # Generated compile files
 /out/
 backend.log
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,7 @@ repositories {
 dependencies {
     api (group: 'org.apache.avro', name: 'avro', version: avroVersion) {
         exclude group: 'org.xerial.snappy', module: 'snappy-java'
-        exclude group: 'com.throughtworks.paranamer', module: 'paranamer'
+        exclude group: 'com.thoughtworks.paranamer', module: 'paranamer'
         exclude group: 'org.apache.commons', module: 'commons-compress'
         exclude group: 'org.tukaani', module: 'xz'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,7 @@ dependencies {
     // For POJO classes and ConfigLoader
     implementation group: 'com.fasterxml.jackson.core' , name: 'jackson-databind' , version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
+    implementation group: 'org.json', name: 'json', version: '20170516'
 
     // The REST data is serialized with okio
     implementation group: 'com.squareup.okio', name: 'okio', version: okioVersion

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ allprojects {
     ext.hamcrestVersion = '1.3'
     ext.codacyVersion = '1.0.10'
     ext.radarSchemasVersion = '0.1'
+    ext.jsonVersion = '20170516'
 
     ext.githubUrl = 'https://github.com/' + githubRepoName + '.git'
     ext.issueUrl = 'https://github.com/' + githubRepoName + '/issues'
@@ -211,7 +212,7 @@ dependencies {
     // For POJO classes and ConfigLoader
     implementation group: 'com.fasterxml.jackson.core' , name: 'jackson-databind' , version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
-    implementation group: 'org.json', name: 'json', version: '20170516'
+    implementation group: 'org.json', name: 'json', version: jsonVersion
 
     // The production code uses the SLF4J logging API at compile time
     implementation group: 'org.slf4j', name:'slf4j-api', version: slf4jVersion

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,11 @@ allprojects {
 
     ext.slf4jVersion = '1.7.21'
     ext.kafkaVersion = '0.10.2.1'
-    ext.avroVersion = '1.8.1'
+    ext.avroVersion = '1.8.2'
     ext.confluentVersion = '3.1.2'
     ext.log4jVersion = '2.7'
     ext.jacksonVersion = '2.8.5'
-    ext.okhttpVersion = '3.6.0'
-    ext.okioVersion = '1.11.0'
+    ext.okhttpVersion = '3.8.0'
     ext.junitVersion = '4.12'
     ext.mockitoVersion = '2.2.29'
     ext.mathVersion = '3.0'
@@ -198,7 +197,12 @@ repositories {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    api group: 'org.apache.avro', name: 'avro', version: avroVersion
+    api (group: 'org.apache.avro', name: 'avro', version: avroVersion) {
+        exclude group: 'org.xerial.snappy', module: 'snappy-java'
+        exclude group: 'com.throughtworks.paranamer', module: 'paranamer'
+        exclude group: 'org.apache.commons', module: 'commons-compress'
+        exclude group: 'org.tukaani', module: 'xz'
+    }
 
     // to implement producers and consumers
     api group: 'org.apache.kafka', name: 'kafka-clients', version: kafkaVersion
@@ -208,9 +212,6 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core' , name: 'jackson-databind' , version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'org.json', name: 'json', version: '20170516'
-
-    // The REST data is serialized with okio
-    implementation group: 'com.squareup.okio', name: 'okio', version: okioVersion
 
     // The production code uses the SLF4J logging API at compile time
     implementation group: 'org.slf4j', name:'slf4j-api', version: slf4jVersion

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
     // Configuration                                                             //
     //---------------------------------------------------------------------------//
 
-    version = '0.5-SNAPSHOT'
+    version = '0.5.1-SNAPSHOT'
     group = 'org.radarcns'
     ext.githubRepoName = 'RADAR-CNS/RADAR-Commons'
 

--- a/src/main/java/org/radarcns/producer/rest/RestSender.java
+++ b/src/main/java/org/radarcns/producer/rest/RestSender.java
@@ -16,7 +16,6 @@
 
 package org.radarcns.producer.rest;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -72,7 +71,6 @@ public class RestSender<K, V> implements KafkaSender<K, V> {
 
     private final AvroEncoder keyEncoder;
     private final AvroEncoder valueEncoder;
-    private final JsonFactory jsonFactory;
 
     private HttpUrl schemalessKeyUrl;
     private HttpUrl schemalessValueUrl;
@@ -101,7 +99,6 @@ public class RestSender<K, V> implements KafkaSender<K, V> {
         this.schemaRetriever = schemaRetriever;
         this.keyEncoder = keyEncoder;
         this.valueEncoder = valueEncoder;
-        this.jsonFactory = new JsonFactory();
         this.useCompression = useCompression;
         this.acceptType = KAFKA_REST_ACCEPT_ENCODING;
         this.contentType = KAFKA_REST_AVRO_ENCODING;
@@ -195,7 +192,7 @@ public class RestSender<K, V> implements KafkaSender<K, V> {
             if (url == null) {
                 throw new MalformedURLException("Cannot parse " + rawUrl);
             }
-            requestData = new TopicRequestData<>(topic, keyEncoder, valueEncoder, jsonFactory);
+            requestData = new TopicRequestData<>(topic, keyEncoder, valueEncoder);
         }
 
         @Override

--- a/src/main/java/org/radarcns/producer/rest/SchemaRetriever.java
+++ b/src/main/java/org/radarcns/producer/rest/SchemaRetriever.java
@@ -37,7 +37,11 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-/** Retriever of an Avro Schema */
+/** Retriever of an Avro Schema.
+ *
+ * Internally, only {@link JSONObject} is used to manage JSON data, to keep the class as lean as
+ * possible.
+ */
 public class SchemaRetriever implements Closeable {
     private static final Logger logger = LoggerFactory.getLogger(SchemaRetriever.class);
     private static final MediaType CONTENT_TYPE = MediaType.parse(

--- a/src/main/java/org/radarcns/producer/rest/TopicRequestData.java
+++ b/src/main/java/org/radarcns/producer/rest/TopicRequestData.java
@@ -58,13 +58,13 @@ class TopicRequestData<K, V> {
         try (OutputStreamWriter writer = new OutputStreamWriter(out)) {
             writer.append('{');
             if (keySchemaId != null) {
-                writer.append("\"key_schema_id\":").append(String.valueOf(keySchemaId));
+                writer.append("\"key_schema_id\":").append(keySchemaId.toString());
             } else {
                 writer.append("\"key_schema\":");
                 JSONObject.quote(keySchemaString, writer);
             }
             if (valueSchemaId != null) {
-                writer.append(",\"value_schema_id\":").append(String.valueOf(valueSchemaId));
+                writer.append(",\"value_schema_id\":").append(valueSchemaId.toString());
             } else {
                 writer.append(",\"value_schema\":");
                 JSONObject.quote(valueSchemaString, writer);


### PR DESCRIPTION
Jackson leaves a huge footprint on Android, switched to `org.json` instead. In fact, because we only use a few functionalities of JSON writing, it is replaced by writing directly to a stream.