### PR TITLE
V0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RADAR-Commons
-[![Build Status](https://travis-ci.org/RADAR-CNS/RADAR-Commons.svg?branch=master)](https://travis-ci.org/RADAR-CNS/RADAR-Commons)
+[![Build Status](https://travis-ci.org/RADAR-CNS/radar-commons.svg?branch=master)](https://travis-ci.org/RADAR-CNS/radar-commons)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9fe7a419c83e4798af671e468c7e91cf)](https://www.codacy.com/app/RADAR-CNS/RADAR-Commons?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=RADAR-CNS/RADAR-Commons&amp;utm_campaign=Badge_Grade)
 
 Common utilities library containing basic schemas, streaming features, testing bridges and utils.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.radarcns', name: 'radar-commons', version: '0.6-alpha.1'
+    compile group: 'org.radarcns', name: 'radar-commons', version: '0.6'
 }
 ```
 
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'org.radarcns', name: 'radar-commons-testing', version: '0.6-alpha.1'
+    testCompile group: 'org.radarcns', name: 'radar-commons-testing', version: '0.6'
 }
 ```
 
@@ -51,7 +51,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.radarcns', name: 'radar-commons', version: '0.6-SNAPSHOT', changing: true
+    compile group: 'org.radarcns', name: 'radar-commons', version: '0.6.1-SNAPSHOT', changing: true
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     // Configuration                                                             //
     //---------------------------------------------------------------------------//
 
-    version = '0.6-alpha.1'
+    version = '0.6.1-SNAPSHOT'
     group = 'org.radarcns'
     ext.githubRepoName = 'RADAR-CNS/RADAR-Commons'
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
     ext.hamcrestVersion = '1.3'
     ext.codacyVersion = '1.0.10'
     ext.radarSchemasVersion = '0.2'
-    ext.jsonVersion = '20170516'
+    ext.orgJsonVersion = '20170516'
 
     ext.githubUrl = 'https://github.com/' + githubRepoName + '.git'
     ext.issueUrl = 'https://github.com/' + githubRepoName + '/issues'
@@ -219,7 +219,7 @@ dependencies {
     // For POJO classes and ConfigLoader
     implementation group: 'com.fasterxml.jackson.core' , name: 'jackson-databind' , version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
-    implementation group: 'org.json', name: 'json', version: jsonVersion
+    implementation group: 'org.json', name: 'json', version: orgJsonVersion
 
     // The production code uses the SLF4J logging API at compile time
     implementation group: 'org.slf4j', name:'slf4j-api', version: slf4jVersion

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
     // Configuration                                                             //
     //---------------------------------------------------------------------------//
 
-    version = '0.6.1-SNAPSHOT'
+    version = '0.6'
     group = 'org.radarcns'
     ext.githubRepoName = 'RADAR-CNS/RADAR-Commons'
 
@@ -52,7 +52,7 @@ allprojects {
     ext.mathVersion = '3.0'
     ext.hamcrestVersion = '1.3'
     ext.codacyVersion = '1.0.10'
-    ext.radarSchemasVersion = '0.2-alpha.3-SNAPSHOT'
+    ext.radarSchemasVersion = '0.2'
     ext.jsonVersion = '20170516'
 
     ext.githubUrl = 'https://github.com/' + githubRepoName + '.git'

--- a/radar-commons-testing/build.gradle
+++ b/radar-commons-testing/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply plugin: 'application'
+apply plugin: 'com.jfrog.artifactory'
 
 mainClassName = 'org.radarcns.mock.MockProducer'
 


### PR DESCRIPTION
Version 0.6

Changes since version 0.6-alpha.1:
- bumped radar-schemas version

Changes since version 0.5:
- Updated radar-schemas to version 0.2 (pending).
- Use `org.json` instead of `com.fasterxml.jackson` for smaller code footprint
- Use Kafka 0.11.0.1 / Confluent 3.3.0
- Added usability methods to RestClient, RestSender and AvroTopic